### PR TITLE
Better connect API

### DIFF
--- a/papi/__init__.py
+++ b/papi/__init__.py
@@ -72,3 +72,26 @@ class Papi:
             nodes=[n.to_yaml(yaml_context=yaml_context) for n in self.nodes.values()],
             edges=[e.to_yaml(yaml_context=yaml_context) for e in self.edges],
         )
+
+    def connect(
+        self,
+        *,
+        source_node: Node,
+        source_type: str,
+        source_key: str,
+        target_node: Node,
+        target_type: str,
+        target_key: str,
+    ) -> Edge:
+        # TODO: add validation
+        assert source_node.papi is target_node.papi is self
+        edge = Edge(
+            source_node=source_node.name,
+            source_type=source_type,
+            source_key=source_key,
+            target_node=target_node.name,
+            target_type=target_type,
+            target_key=target_key,
+        )
+        self.edges.append(edge)
+        return edge

--- a/papi/edges.py
+++ b/papi/edges.py
@@ -42,15 +42,11 @@ class EdgeDescriptor:
     key: str
 
     def to(self, dest: "EdgeDescriptor"):
-        # TODO: add validation
-        assert self.node.papi is dest.node.papi
-        self.node.papi.edges.append(
-            Edge(
-                source_node=self.node.name,
-                source_type=self.type,
-                source_key=self.key,
-                target_node=dest.node.name,
-                target_type=dest.type,
-                target_key=dest.key,
-            )
+        return self.node.papi.connect(
+            source_node=self.node,
+            source_type=self.type,
+            source_key=self.key,
+            target_node=dest.node,
+            target_type=dest.type,
+            target_key=dest.key,
         )

--- a/papi/nodes.py
+++ b/papi/nodes.py
@@ -18,10 +18,22 @@ class Node(PapiObject, metaclass=ABCMeta):
         self.name = name
 
     def output(self, key: str) -> EdgeDescriptor:
-        return EdgeDescriptor(node=self, type="output", key=key)
+        return self.output_edge(key)
 
     def input(self, key: str) -> EdgeDescriptor:
+        return self.input_edge(key)
+
+    def output_edge(self, key: str) -> EdgeDescriptor:
+        return EdgeDescriptor(node=self, type="output", key=key)
+
+    def input_edge(self, key: str) -> EdgeDescriptor:
         return EdgeDescriptor(node=self, type="input", key=key)
+
+    def parameter_edge(self, key: str) -> EdgeDescriptor:
+        return EdgeDescriptor(node=self, type="parameter", key=key)
+
+    def metadata_edge(self, key: str) -> EdgeDescriptor:
+        return EdgeDescriptor(node=self, type="metadata", key=key)
 
 
 class ExecutionNode(Node):

--- a/papi_tests/test_param_param.py
+++ b/papi_tests/test_param_param.py
@@ -1,0 +1,10 @@
+from papi import Papi
+from papi_examples.utils import read_config
+
+
+def test_param_param_edge():
+    papi = Papi(name="mypipeline", config=read_config("example1.yaml"))
+    t1 = papi.task("Train model")
+    t2 = papi.task("Train model")
+    t1.parameter_edge("learning_rate").to(t2.parameter_edge("learning_rate"))
+    assert len(papi.edges) == 1


### PR DESCRIPTION
This PR adds more functions for creating edges.

For creating parameter edges, you currently need to

```
EdgeDescriptor(node=t1, type="parameter", key="learning_rate").to(EdgeDescriptor(node=t2, type="parameter", key="learning_rate"))
```

With this PR, the equivalent syntax is

```
t1.parameter_edge("learning_rate").to(t2.parameter_edge("learning_rate"))
```

Much nicer.

❓  However, `*_edge` is a bit of a misnomer, since what it really returns is an edge descriptor you can connect to... Is that a problem?