### PR TITLE
Give Papi exceptions real types and context

### DIFF
--- a/papi/__init__.py
+++ b/papi/__init__.py
@@ -5,6 +5,7 @@ from valohai_yaml.objs import Config, Pipeline, Step
 
 from papi.contexts import APIContext, YAMLContext
 from papi.edges import Edge
+from papi.excs import DuplicateNode, MissingObject
 from papi.nodes import ExecutionNode, Node, TaskNode
 
 __all__ = ["Papi"]
@@ -31,7 +32,7 @@ class Papi:
 
     def _register_node(self, node: SomeNode) -> SomeNode:
         if node.name in self.nodes:
-            raise ValueError(f"Duplicate node {node}")
+            raise DuplicateNode(f"Duplicate node {node}", papi=self)
         self.nodes[node.name] = node
         node.papi = self
         return node
@@ -47,7 +48,7 @@ class Papi:
     def _get_step(self, name) -> Step:
         step_object: Optional[Step] = self.config.get_step_by(name=name)
         if not step_object:
-            raise ValueError(f"no such step {name} in config")
+            raise MissingObject(f"no such step {name} in config", papi=self)
         return step_object
 
     def task(self, step: str, name: str = None) -> TaskNode:

--- a/papi/excs.py
+++ b/papi/excs.py
@@ -1,0 +1,20 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from papi import Papi
+
+
+class PapiErrorMixin:
+    papi: "Papi"
+
+    def __init__(self, *args, papi: "Papi"):
+        self.papi = papi
+        super().__init__(*args)
+
+
+class DuplicateNode(PapiErrorMixin, ValueError):
+    pass
+
+
+class MissingObject(PapiErrorMixin, ValueError):
+    pass

--- a/papi/nodes.py
+++ b/papi/nodes.py
@@ -7,6 +7,7 @@ from valohai_yaml.utils import listify
 
 from .base import PapiObject
 from .edges import EdgeDescriptor
+from .excs import MissingObject
 from .utils import compact_dict
 
 
@@ -71,12 +72,14 @@ class ExecutionNode(Node):
 
     def input(self, key: str) -> EdgeDescriptor:
         if key not in self.step.inputs:
-            raise ValueError(f"{key} not known in {self.step.name}")
+            raise MissingObject(f"{key} not known in {self.step.name}", papi=self.papi)
         return super().input(key)
 
     def _check_parameter_name(self, name):
         if name not in self.step.parameters:
-            raise ValueError(f"No such parameter {name}")
+            raise MissingObject(
+                f"No such parameter {name} in {self.step.name}", papi=self.papi
+            )
 
 
 class TaskNode(ExecutionNode):


### PR DESCRIPTION
This will make it easier for downstream utilities to catch errors and figure out what's happening.

Refs valohai/valohai-cli#156